### PR TITLE
improves binutils search on macos with brew

### DIFF
--- a/packages/bap-cxxfilt/bap-cxxfilt.1.0.0/opam
+++ b/packages/bap-cxxfilt/bap-cxxfilt.1.0.0/opam
@@ -25,7 +25,7 @@ depends: [
   "ocaml"
   "bap-std" {= "1.0.0"}
   "bap-demangle" {= "1.0.0"}
-  "conf-binutils" {>= "0.2"}
+  "conf-binutils" {= "0.2"}
 ]
 synopsis: "A demangler that relies on a c++filt utility"
 url {

--- a/packages/bap-cxxfilt/bap-cxxfilt.1.1.0/opam
+++ b/packages/bap-cxxfilt/bap-cxxfilt.1.1.0/opam
@@ -25,7 +25,7 @@ depends: [
   "ocaml"
   "bap-std" {= "1.1.0"}
   "bap-demangle" {= "1.1.0"}
-  "conf-binutils" {>= "0.2"}
+  "conf-binutils" {= "0.2"}
 ]
 synopsis: "A demangler that relies on a c++filt utility"
 url {

--- a/packages/bap-cxxfilt/bap-cxxfilt.1.2.0/opam
+++ b/packages/bap-cxxfilt/bap-cxxfilt.1.2.0/opam
@@ -25,7 +25,7 @@ depends: [
   "ocaml"
   "bap-std" {= "1.2.0"}
   "bap-demangle" {= "1.2.0"}
-  "conf-binutils" {>= "0.2"}
+  "conf-binutils" {= "0.2"}
 ]
 synopsis: "A demangler that relies on a c++filt utility"
 url {

--- a/packages/bap-cxxfilt/bap-cxxfilt.1.3.0/opam
+++ b/packages/bap-cxxfilt/bap-cxxfilt.1.3.0/opam
@@ -24,7 +24,7 @@ depends: [
   "ocaml"
   "bap-std" {= "1.3.0"}
   "bap-demangle" {= "1.3.0"}
-  "conf-binutils" {>= "0.2"}
+  "conf-binutils" {= "0.2"}
 ]
 synopsis: "A demangler that relies on a c++filt utility"
 url {

--- a/packages/bap-cxxfilt/bap-cxxfilt.1.4.0/opam
+++ b/packages/bap-cxxfilt/bap-cxxfilt.1.4.0/opam
@@ -24,7 +24,7 @@ depends: [
   "ocaml" {>= "4.03" & < "4.06"}
   "bap-std" {= "1.4.0"}
   "bap-demangle" {= "1.4.0"}
-  "conf-binutils" {>= "0.2"}
+  "conf-binutils" {= "0.2"}
 ]
 synopsis: "A demangler that relies on a c++filt utility"
 url {

--- a/packages/bap-cxxfilt/bap-cxxfilt.1.5.0/opam
+++ b/packages/bap-cxxfilt/bap-cxxfilt.1.5.0/opam
@@ -24,7 +24,7 @@ depends: [
   "ocaml" {>= "4.03" & < "4.06"}
   "bap-std" {= "1.5.0"}
   "bap-demangle" {= "1.5.0"}
-  "conf-binutils" {>= "0.2"}
+  "conf-binutils" {= "0.2"}
 ]
 synopsis: "A demangler that relies on a c++filt utility"
 url {

--- a/packages/bap-cxxfilt/bap-cxxfilt.1.6.0/opam
+++ b/packages/bap-cxxfilt/bap-cxxfilt.1.6.0/opam
@@ -24,7 +24,7 @@ depends: [
   "ocaml" {>= "4.04.1" & < "4.08.0"}
   "bap-std" {= "1.6.0"}
   "bap-demangle" {= "1.6.0"}
-  "conf-binutils" {>= "0.2"}
+  "conf-binutils" {= "0.2"}
 ]
 synopsis: "A demangler that relies on a c++filt utility"
 url {

--- a/packages/bap-cxxfilt/bap-cxxfilt.2.0.0/opam
+++ b/packages/bap-cxxfilt/bap-cxxfilt.2.0.0/opam
@@ -24,7 +24,7 @@ depends: [
   "ocaml" {>= "4.04.1" & < "4.08.0"}
   "bap-std" {= "2.0.0"}
   "bap-demangle"
-  "conf-binutils" {>= "0.2"}
+  "conf-binutils" {= "0.2"}
 ]
 synopsis: "A demangler that relies on a c++filt utility"
 url {

--- a/packages/bap-cxxfilt/bap-cxxfilt.2.1.0/opam
+++ b/packages/bap-cxxfilt/bap-cxxfilt.2.1.0/opam
@@ -24,7 +24,7 @@ depends: [
   "ocaml" {>= "4.07.0" & < "4.10.0"}
   "bap-std" {= "2.1.0"}
   "bap-demangle"
-  "conf-binutils" {>= "0.2"}
+  "conf-binutils" {= "0.2"}
 ]
 synopsis: "A demangler that relies on a c++filt utility"
 url {

--- a/packages/bap-objdump/bap-objdump.1.0.0/opam
+++ b/packages/bap-objdump/bap-objdump.1.0.0/opam
@@ -24,7 +24,7 @@ depends: [
   "bap-std" {= "1.0.0"}
   "re"
   "cmdliner"
-  "conf-binutils"
+  "conf-binutils" {<= "0.2"}
 ]
 synopsis: "Extract symbols from binary, using binutils objdump"
 url {

--- a/packages/bap-objdump/bap-objdump.1.1.0/opam
+++ b/packages/bap-objdump/bap-objdump.1.1.0/opam
@@ -24,7 +24,7 @@ depends: [
   "bap-std" {= "1.1.0"}
   "re"
   "cmdliner"
-  "conf-binutils"
+  "conf-binutils" {<= "0.2"}
 ]
 synopsis: "Extract symbols from binary, using binutils objdump"
 url {

--- a/packages/bap-objdump/bap-objdump.1.2.0/opam
+++ b/packages/bap-objdump/bap-objdump.1.2.0/opam
@@ -24,7 +24,7 @@ depends: [
   "bap-std" {= "1.2.0"}
   "re"
   "cmdliner"
-  "conf-binutils"
+  "conf-binutils" {<= "0.2"}
 ]
 synopsis: "Extract symbols from binary, using binutils objdump"
 url {

--- a/packages/bap-objdump/bap-objdump.1.3.0/opam
+++ b/packages/bap-objdump/bap-objdump.1.3.0/opam
@@ -24,7 +24,7 @@ depends: [
   "bap-std" {= "1.3.0"}
   "re"
   "cmdliner"
-  "conf-binutils"
+  "conf-binutils" {<= "0.2"}
 ]
 synopsis: "Extract symbols from binary, using binutils objdump"
 url {

--- a/packages/bap-objdump/bap-objdump.1.4.0/opam
+++ b/packages/bap-objdump/bap-objdump.1.4.0/opam
@@ -24,7 +24,7 @@ depends: [
   "bap-std" {= "1.4.0"}
   "re" {< "1.7.2"}
   "cmdliner"
-  "conf-binutils"
+  "conf-binutils" {<= "0.2"}
 ]
 synopsis: "Extract symbols from binary, using binutils objdump"
 url {

--- a/packages/bap-objdump/bap-objdump.1.5.0/opam
+++ b/packages/bap-objdump/bap-objdump.1.5.0/opam
@@ -24,7 +24,7 @@ depends: [
   "bap-std" {= "1.5.0"}
   "re" {< "1.7.2"}
   "cmdliner"
-  "conf-binutils"
+  "conf-binutils" {<= "0.2"}
 ]
 synopsis: "Extract symbols from binary, using binutils objdump"
 url {

--- a/packages/bap-objdump/bap-objdump.1.6.0/opam
+++ b/packages/bap-objdump/bap-objdump.1.6.0/opam
@@ -24,7 +24,7 @@ depends: [
   "bap-std" {= "1.6.0"}
   "re"
   "cmdliner"
-  "conf-binutils"
+  "conf-binutils" {<= "0.2"}
 ]
 synopsis: "Extract symbols from binary, using binutils objdump"
 url {

--- a/packages/bap-objdump/bap-objdump.2.0.0/opam
+++ b/packages/bap-objdump/bap-objdump.2.0.0/opam
@@ -24,7 +24,7 @@ depends: [
   "bap-std" {= "2.0.0"}
   "re"
   "cmdliner"
-  "conf-binutils"
+  "conf-binutils" {<= "0.2"}
 ]
 synopsis: "Extract symbols from binary, using binutils objdump"
 url {

--- a/packages/bap-objdump/bap-objdump.2.1.0/opam
+++ b/packages/bap-objdump/bap-objdump.2.1.0/opam
@@ -24,7 +24,7 @@ depends: [
   "bap-std" {= "2.1.0"}
   "re"
   "cmdliner"
-  "conf-binutils"
+  "conf-binutils" {<= "0.2"}
 ]
 synopsis: "Extract symbols from binary, using binutils objdump"
 url {

--- a/packages/clangml-transforms/clangml-transforms.0.26/opam
+++ b/packages/clangml-transforms/clangml-transforms.0.26/opam
@@ -9,10 +9,11 @@ bug-reports: "https://gitlab.inria.fr/memcad/clangml-transforms/issues"
 depends: [
   "ocaml" {>= "4.03.0" & < "4.12.0"}
   "dune" {>= "1.11.0"}
-  "clangml" {>= "4.1.0" & < "4.2.0"}
+  "clangml" {>= "4.2.0"}
   "dolog" {>= "4.0.0"}
   "traverse" {>= "0.2.0"}
-  "refl" {>= "0.1.0"}
+  "refl" {>= "0.2.1"}
+  "odoc" {with-doc & >= "1.5.1"}
 ]
 build: [
   ["dune" "subst"] {pinned}
@@ -30,6 +31,6 @@ build: [
 ]
 dev-repo: "git+https://gitlab.inria.fr/memcad/clangml-transforms"
 url {
-  src: "https://gitlab.inria.fr/memcad/clangml-transforms/-/archive/v0.25/clangml-transforms-v0.25.tar.gz"
-  checksum: "sha512=7432844f7be84ce89299d8611fe6379b1174eb24723dc9e8805ba75f2b700475f281cef13c7b8a40f54776e57200a288fcde1210c77686c0f693df665f535414"
+  src: "https://gitlab.inria.fr/memcad/clangml-transforms/-/archive/v0.26/clangml-transforms-v0.26.tar.gz"
+  checksum: "sha512=857529df94db8c07e55b3919ef3e8a3fa4b297faedb9811d181d3f8554392898fc56985dfcd86726b1925d4ba7846158a907a5e18133cd597de639c780be615e"
 }

--- a/packages/clangml/clangml.4.2.0/opam
+++ b/packages/clangml/clangml.4.2.0/opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+synopsis: "OCaml bindings for Clang API"
+description: """
+clangml provides bindings to call the Clang API from OCaml.
+"""
+maintainer: ["Thierry Martinez <thierry.martinez@inria.fr>"]
+authors: ["Thierry Martinez <thierry.martinez@inria.fr>"]
+license: "BSD-2-Clause"
+homepage: "https://memcad.gitlabpages.inria.fr/clangml/"
+doc: "https://memcad.gitlabpages.inria.fr/clangml/doc/clangml/index.html"
+bug-reports: "https://gitlab.inria.fr/memcad/clangml/issues"
+depends: [
+  "conf-libclang"
+  "conf-ncurses"
+  "conf-zlib"
+  "dune" {>= "1.11.0"}
+  "stdcompat" {>= "13"}
+  "ocaml" {>= "4.03.0" & < "4.12.0"}
+  "ocamlfind" {build & >= "1.8.0"}
+  "ocamlcodoc" {with-test & >= "1.0.1"}
+  "pattern" {with-test & >= "0.2.0"}
+  "metapp" {>= "0.1.0"}
+  "metaquot" {>= "0.1.0"}
+  "refl" {>= "0.2.0"}
+  "odoc" {with-doc & >= "1.5.1"}
+]
+dev-repo: "git+https://gitlab.inria.fr/memcad/clangml"
+build: [
+  ["./configure" "--prefix=%{prefix}%" "--with-llvm-config=%{conf-libclang:config}%"]
+  ["dune" "build" "-p" name "-j" jobs "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}]]
+url {
+  src: "https://gitlab.inria.fr/memcad/clangml/-/archive/v4.2.0/clangml-v4.2.0.tar.gz"
+  checksum: "sha512=67957797a1d97072c001056f60f831c1cb4942435f07fc36e3dad6696c6a2dd3fdb5ba1d7ffc50a54b1dda31b2c13d117ec9fa80ca43cfd3ea2856a5110ba9f9"
+}

--- a/packages/conf-binutils/conf-binutils.0.2/files/find-binutils.ml.in
+++ b/packages/conf-binutils/conf-binutils.0.2/files/find-binutils.ml.in
@@ -120,13 +120,13 @@ let collect_targets objdumps =
         Filename.chop_suffix file "-objdump" :: acc
       else acc) [] objdumps
 
-let which = cmd "which %s"
+let which name () = cmd "which %s" name
 
-let of_env var =
+let of_env var () =
   try Some (Sys.getenv var)
   with Not_found -> None
 
-let find_in_cellar name =
+let find_in_cellar name () =
   match cmd "brew --cellar" with
   | None -> None
   | Some cellar ->
@@ -136,7 +136,7 @@ let find_in_cellar name =
       | [] -> None
       | x :: _ -> Some x
 
-let of_opam_config = function
+let of_opam_config var () = match var with
   | "" -> None
   | x  -> Some x
 
@@ -144,39 +144,41 @@ let is_some = function
   | Some _ -> true
   | None -> false
 
-let find_some xs =
-  try
-    List.find is_some xs
-  with Not_found -> None
+let rec first_success = function
+  | [] -> None
+  | f :: fs ->  match f () with
+    | None -> first_success fs
+    | r -> r
 
 let find_objdump () =
-  find_some [of_opam_config "%{objdump-path}%";
-             of_env "OBJDUMP_PATH";]
+  first_success
+    [of_opam_config "%{objdump-path}%";
+     of_env "OBJDUMP_PATH";]
 
 let find_cppfilt () =
-  find_some [of_opam_config "%{cxxfilt-path}%";
-             of_env "CXXFILT_PATH";]
+  first_success [of_opam_config "%{cxxfilt-path}%";
+                 of_env "CXXFILT_PATH";]
 
 let () =
   try
     match "%{os}%" with
     | "linux" ->
-      let objdump = find_some [
-          find_objdump ();
+      let objdump = first_success [
+          find_objdump;
           which "objdump"] in
-      let cxxfilt = find_some [
-          find_cppfilt ();
+      let cxxfilt = first_success [
+          find_cppfilt;
           which "c++filt"] in
       let objdumps = collect_objdumps () in
       let targets = collect_targets objdumps in
       write objdump cxxfilt targets
     | "macos" ->
-      let objdump = find_some [
-          find_objdump ();
+      let objdump = first_success [
+          find_objdump;
           which "gobjdump";
           find_in_cellar "gobjdump"; ] in
-      let cxxfilt = find_some [
-          find_cppfilt ();
+      let cxxfilt = first_success [
+          find_cppfilt;
           which "c++filt";
           find_in_cellar "cppfilt"; ] in
       let objdumps = split_results "mdfind -name objdump" in

--- a/packages/conf-binutils/conf-binutils.0.2/files/find-binutils.ml.in
+++ b/packages/conf-binutils/conf-binutils.0.2/files/find-binutils.ml.in
@@ -47,7 +47,9 @@ let cmd fmt =
       | Unix.WEXITED 0 -> Some res
       | s -> raise (Command_failed s)
     with e ->
+      printf "got an exception!\n";
       eprintf "command %s failed: %s\n" c (exn_to_string e);
+      printf "none will be returned\n";
       None in
   ksprintf run fmt
 
@@ -56,14 +58,6 @@ let split_results fmt =
     match cmd "%s" c with
     | None -> []
     | Some s -> split s in
-  ksprintf run fmt
-
-let hd_opt xs = List.nth_opt xs 0
-
-let take_first fmt =
-  let run c = match cmd "%s" c with
-    | None -> None
-    | Some s -> hd_opt (split s) in
   ksprintf run fmt
 
 let string_of_targets targets =
@@ -138,43 +132,55 @@ let find_in_cellar name =
   match cmd "brew --cellar" with
   | None -> None
   | Some cellar ->
-    take_first "find %s/binutils -name %s" cellar name
+    match cmd "find %s/binutils -name %s" cellar name with
+    | None -> None
+    | Some s -> match split s with
+      | [] -> None
+      | x :: _ -> Some x
 
 let of_opam_config = function
   | "" -> None
   | x  -> Some x
 
-let rec find_map xs =
-  match xs with
-  | [] -> None
-  | x :: xs -> match x with
-    | None -> find_map xs
-    | x -> x
+let is_some = function
+  | Some _ -> true
+  | None -> false
+
+let find_some xs =
+  try
+    List.find is_some xs
+  with Not_found -> None
 
 let find_objdump () =
-  find_map [of_opam_config "%{objdump-path}%";
-            of_env "OBJDUMP_PATH";]
+  find_some [of_opam_config "%{objdump-path}%";
+             of_env "OBJDUMP_PATH";]
 
 let find_cppfilt () =
-  find_map [of_opam_config "%{cppfilt-path}%";
-            of_env "CPPFILT_PATH";]
+  find_some [of_opam_config "%{cxxfilt-path}%";
+             of_env "CXXFILT_PATH";]
 
 let () =
   try
     match "%{os}%" with
     | "linux" ->
-      let objdump = find_map [find_objdump (); which "objdump"] in
-      let cxxfilt = find_map [find_cppfilt (); which "c++filt"] in
+      let objdump = find_some [
+          find_objdump ();
+          which "objdump"] in
+      let cxxfilt = find_some [
+          find_cppfilt ();
+          which "c++filt"] in
       let objdumps = collect_objdumps () in
       let targets = collect_targets objdumps in
       write objdump cxxfilt targets
     | "macos" ->
-      let objdump = find_map [find_objdump ();
-                              which "gobjdump";
-                              find_in_cellar "gobjdump"; ] in
-      let cxxfilt = find_map [find_cppfilt ();
-                              which "c++filt";
-                              find_in_cellar "cppfilt"; ] in
+      let objdump = find_some [
+          find_objdump ();
+          which "gobjdump";
+          find_in_cellar "gobjdump"; ] in
+      let cxxfilt = find_some [
+          find_cppfilt ();
+          which "c++filt";
+          find_in_cellar "cppfilt"; ] in
       let objdumps = split_results "mdfind -name objdump" in
       let objdumps = List.filter (fun x -> not (Sys.is_directory x)) objdumps in
       let targets = collect_targets objdumps in

--- a/packages/conf-binutils/conf-binutils.0.2/files/find-binutils.ml.in
+++ b/packages/conf-binutils/conf-binutils.0.2/files/find-binutils.ml.in
@@ -144,19 +144,20 @@ let update t path  =
 
 let collect t pathes = List.fold_left pathes ~f:update ~init:t
 
-let collect_leaf_folders path =
-  let collect_folders path =
-    Sys.readdir path |>
-    Array.fold_left ~init:[] ~f:(fun acc d ->
-        let path' = path / d in
-        if Sys.is_directory path' then path' :: acc
-        else acc) in
-  let rec read acc path =
-    match collect_folders path with
-    | [] -> path :: acc
-    | subdirs -> List.fold_left subdirs ~f:read ~init:acc in
-  collect_folders path |>
-  List.fold_left ~init:[] ~f:read
+let search t path =
+  let rec loop t path =
+    if Sys.is_directory path
+    then
+      Sys.readdir path |>
+      Array.fold_left ~init:t ~f:(fun t file -> loop t @@ path / file)
+    else
+      Vars.fold (fun name tool t ->
+          if tool.test (Filename.basename path)
+          then
+            let file = {path; dgst = digest path} in
+            Vars.add name {tool with files = tool.files @ [file]} t
+          else t) t t in
+  loop t path
 
 let rec first_success = function
   | [] -> None
@@ -195,7 +196,7 @@ let add_var name ~file ~test t =
   Vars.add name {test; main; files = []} t
 
 let is_objdump file =
-  Filename.check_suffix "objdump" file &&
+  Filename.check_suffix file "objdump" &&
   not (has_prefix file "llvm")
 
 let is_cxxfilt file = Filename.check_suffix file "c++filt"
@@ -211,18 +212,16 @@ let t =
 
 let () =
   try
-    let pathes = match "%{os}%" with
-      | "linux" -> all_pathes ()
-      | "macos" ->
-        let pathes = match cmd "brew --cellar" with
-          | None -> all_pathes ()
-          | Some cellar ->
-            collect_leaf_folders cellar @ all_pathes () in
-        pathes
-      | s ->
-        eprintf "unsupported OS %s\n" s;
-        exit 1 in
-    write @@ collect t pathes
+    match "%{os}%" with
+    | "linux" -> write @@ collect t @@ all_pathes ()
+    | "macos" ->
+      let t = match cmd "brew --cellar" with
+        | None -> t
+        | Some cellar -> search t cellar in
+      write @@ collect t @@ all_pathes ()
+    | s ->
+      eprintf "unsupported OS %s\n" s;
+      exit 1
   with e ->
     eprintf "build failed: %s\n" (Printexc.to_string e);
     exit 1

--- a/packages/conf-binutils/conf-binutils.0.2/files/find-binutils.ml.in
+++ b/packages/conf-binutils/conf-binutils.0.2/files/find-binutils.ml.in
@@ -58,6 +58,14 @@ let split_results fmt =
     | Some s -> split s in
   ksprintf run fmt
 
+let hd_opt xs = List.nth_opt xs 0
+
+let take_first fmt =
+  let run c = match cmd "%s" c with
+    | None -> None
+    | Some s -> hd_opt (split s) in
+  ksprintf run fmt
+
 let string_of_targets targets =
   List.fold_left (fun acc x ->
       sprintf "%s\"%s\"; " acc x) "[" targets ^ "]"
@@ -122,18 +130,51 @@ let collect_targets objdumps =
 
 let which = cmd "which %s"
 
+let of_env var =
+  try Some (Sys.getenv var)
+  with Not_found -> None
+
+let find_in_cellar name =
+  match cmd "brew --cellar" with
+  | None -> None
+  | Some cellar ->
+    take_first "find %s/binutils -name %s" cellar name
+
+let of_opam_config = function
+  | "" -> None
+  | x  -> Some x
+
+let rec find_map xs =
+  match xs with
+  | [] -> None
+  | x :: xs -> match x with
+    | None -> find_map xs
+    | x -> x
+
+let find_objdump () =
+  find_map [of_opam_config "%{objdump-path}%";
+            of_env "OBJDUMP_PATH";]
+
+let find_cppfilt () =
+  find_map [of_opam_config "%{cppfilt-path}%";
+            of_env "CPPFILT_PATH";]
+
 let () =
   try
     match "%{os}%" with
     | "linux" ->
-      let objdump = which "objdump" in
-      let cxxfilt = which "c++filt" in
+      let objdump = find_map [find_objdump (); which "objdump"] in
+      let cxxfilt = find_map [find_cppfilt (); which "c++filt"] in
       let objdumps = collect_objdumps () in
       let targets = collect_targets objdumps in
       write objdump cxxfilt targets
     | "macos" ->
-      let objdump= which "gobjdump" in
-      let cxxfilt = which "c++filt" in
+      let objdump = find_map [find_objdump ();
+                              which "gobjdump";
+                              find_in_cellar "gobjdump"; ] in
+      let cxxfilt = find_map [find_cppfilt ();
+                              which "c++filt";
+                              find_in_cellar "cppfilt"; ] in
       let objdumps = split_results "mdfind -name objdump" in
       let objdumps = List.filter (fun x -> not (Sys.is_directory x)) objdumps in
       let targets = collect_targets objdumps in

--- a/packages/conf-binutils/conf-binutils.0.2/files/find-binutils.ml.in
+++ b/packages/conf-binutils/conf-binutils.0.2/files/find-binutils.ml.in
@@ -1,14 +1,25 @@
 open Printf
+open StdLabels
 
-
-type t = {
-  objdump  : string option;
-  cxxfilt  : string option;
-  objdumps : string list;
-  cxxfilts : string list;
+type file = {
+  path : string;
+  dgst : string;
 }
 
+type tool = {
+  test  : string -> bool;
+  main  : file option;
+  files : file list;
+}
+
+module Digests = Set.Make(String)
+module Vars = Map.Make(String)
+
+type t = tool Vars.t
+
 let (/) = Filename.concat
+
+let digest path = Digest.to_hex (Digest.file path)
 
 let read_all ch =
   let buf = Buffer.create 16 in
@@ -31,7 +42,7 @@ let split_on_char sep s =
 
 let split ~on str =
   List.map String.trim (split_on_char on str) |>
-  List.filter (fun s -> s <> "")
+  List.filter ~f:(fun s -> s <> "")
 
 exception Command_failed of Unix.process_status
 
@@ -59,16 +70,9 @@ let cmd fmt =
       None in
   ksprintf run fmt
 
-let split_results fmt =
-  let run c =
-    match cmd "%s" c with
-    | None -> []
-    | Some s -> split ~on:'\n' s in
-  ksprintf run fmt
-
-let string_of_list xs =
-  List.fold_left (fun acc x ->
-      sprintf "%s\"%s\"; " acc x) "[" xs ^ "]"
+let string_of_files xs =
+  List.fold_left xs ~f:(fun s {path} ->
+      sprintf "%s\"%s\"; " s path) ~init:"[" ^ "]"
 
 let is_none = function
   | None -> true
@@ -78,57 +82,81 @@ let failed_to_find cmd =
   eprintf "%s not found\n" cmd;
   exit 1
 
-let write {objdump; objdumps; cxxfilt; cxxfilts;} =
-  if is_none objdump then failed_to_find "objdump";
-  if is_none cxxfilt then failed_to_find "c++filt";
-  let digest path = Digest.to_hex (Digest.file path) in
-  let depends = function
-    | None -> ""
-    | Some file ->
-      sprintf "[ %S %S ]" file (digest file) in
-  let get x = match x with
-    | None -> ""
-    | Some x -> x in
-  let file_depends =
-    let deps = String.concat " " [depends objdump; depends cxxfilt] in
-    if deps = "" then ""
-    else sprintf "file-depends: [ %s ]" deps in
+let dedup main files =
+  fst @@
+  List.fold_left files
+    ~init:([], Digests.add main.dgst Digests.empty)
+    ~f:(fun ((files, digests) as acc) ({dgst} as file) ->
+        if Digests.mem dgst digests
+        then acc
+        else file :: files, Digests.add dgst digests)
+
+let dependencies ~init files =
+  List.fold_left files ~init ~f:(fun depends {path; dgst} ->
+      sprintf " [ %S %S ] " path dgst :: depends)
+
+let write t =
+  let deps, vars =
+    Vars.fold (fun name {main; files} (deps, vars) ->
+        let main, files = match main, files with
+          | None, [] -> failed_to_find name
+          | None, main :: files -> main, files
+          | Some main, files -> main, files in
+        let files = dedup main files in
+        let deps = dependencies ~init:deps (main :: files) in
+        let main = sprintf "%s: %S" name main.path in
+        let files = sprintf "%ss: %S" name (string_of_files files) in
+        deps, main :: files :: vars) t ([], [])  in
   let oc = open_out "%{_:name}%.config" in
+  let deps = String.concat "\n" deps in
+  let vars = String.concat "\n" vars in
   fprintf oc {|
 opam-version: "2.0"
-%s
+file-depends: [ %s ]
 variables {
-  cxxfilt: %S
-  cxxfilts: %S
-  objdump: %S
-  objdumps: %S
+%s
 }
-|} file_depends
-    (get cxxfilt) (string_of_list cxxfilts)
-    (get objdump) (string_of_list objdumps);
+|} deps vars;
   close_out oc
-
-let which name () = cmd "which %s" name
 
 let of_env var () =
   try Some (Sys.getenv var)
   with Not_found -> None
 
-let cellar () = cmd "brew --cellar"
-
-let find_in_cellar name () =
-  match cmd "brew --cellar" with
-  | None -> None
-  | Some cellar ->
-    match cmd "find %s/binutils -name %s" cellar name with
-    | None -> None
-    | Some s -> match split ~on:'\n' s with
-      | [] -> None
-      | x :: _ -> Some x
-
 let of_opam_config var () = match var with
   | "" -> None
   | x  -> Some x
+
+let match_files path files test =
+  Array.fold_left files ~init:[] ~f:(fun acc file ->
+      if test file then
+        let path = path / file in
+        {path; dgst = digest path} :: acc
+      else acc)
+
+let update t path  =
+  if Sys.is_directory path then
+    let files = Sys.readdir path in
+    Vars.fold (fun name tool t ->
+        let files = match_files path files tool.test in
+        Vars.add name {tool with files = tool.files @ files} t) t t
+  else t
+
+let collect t pathes = List.fold_left pathes ~f:update ~init:t
+
+let collect_leaf_folders path =
+  let collect_folders path =
+    Sys.readdir path |>
+    Array.fold_left ~init:[] ~f:(fun acc d ->
+        let path' = path / d in
+        if Sys.is_directory path' then path' :: acc
+        else acc) in
+  let rec read acc path =
+    match collect_folders path with
+    | [] -> path :: acc
+    | subdirs -> List.fold_left subdirs ~f:read ~init:acc in
+  collect_folders path |>
+  List.fold_left ~init:[] ~f:read
 
 let rec first_success = function
   | [] -> None
@@ -148,86 +176,53 @@ let find_cxxfilt () =
     of_env "CXXFILT_PATH";
   ]
 
+let is_dir p = Sys.file_exists p && Sys.is_directory p
+
 let all_pathes () =
   match of_env "PATH" () with
   | None -> []
-  | Some r -> split r ~on:':'
-
-let filter_objdumps objs =
-  let has_prefix str pref =
-    let len = String.length pref in
-    len <= String.length str &&
-    String.(sub str 0 len = pref) in
-  List.fold_left (fun acc obj ->
-      let file = Filename.basename obj in
-      if file = "objdump" || file = "gobjdump" || has_prefix file "llvm"
-      then acc
-      else
-      if Filename.check_suffix file "-objdump" then
-        Filename.chop_suffix file "-objdump" :: acc
-      else acc) [] objs
+  | Some r -> List.filter ~f:is_dir (split r ~on:':')
 
 let has_prefix str pref =
   let len = String.length pref in
   len <= String.length str &&
   String.(sub str 0 len = pref)
 
-let collect t pathes =
-  let is_known fullpath = function
-    | None -> false
-    | Some x -> x = fullpath in
-  let is_objdump path file =
-    Filename.check_suffix file "objdump" &&
-    not (is_known (path/file) t.objdump) &&
-    not (has_prefix file "llvm") in
-  let is_cxxfilt path file =
-    not (is_known (path/file) t.cxxfilt) &&
-    Filename.check_suffix file "c++filt" in
-  let find t path =
-    if Sys.file_exists path && Sys.is_directory path then
-      Sys.readdir path |>
-      Array.fold_left (fun t file ->
-          if is_objdump path file then
-            {t with objdumps = path / file :: t.objdumps}
-          else if is_cxxfilt path file then
-            {t with cxxfilts = path / file :: t.cxxfilts}
-          else t) t
-    else t in
-  List.fold_left find t pathes
+let add_var name ~file ~test t =
+  let main = match file with
+    | None -> None
+    | Some path -> Some {path; dgst = digest path }  in
+  Vars.add name {test; main; files = []} t
+
+let is_objdump file =
+  Filename.check_suffix "objdump" file &&
+  not (has_prefix file "llvm")
+
+let is_cxxfilt file = Filename.check_suffix file "c++filt"
+
+let t =
+  add_var "objdump"
+    ~file:(find_objdump ())
+    ~test:is_objdump
+    Vars.empty |>
+  add_var "cxxfilt"
+    ~file:(find_cxxfilt ())
+    ~test:is_cxxfilt
 
 let () =
   try
-    match "%{os}%" with
-    | "linux" ->
-      let objdump = first_success [
-          find_objdump;
-          which "objdump"] in
-      let cxxfilt = first_success [
-          find_cxxfilt;
-          which "c++filt"] in
-      let t = collect
-          {objdump; cxxfilt; objdumps=[]; cxxfilts=[]}
-          (all_pathes ()) in
-      write t
-    | "macos" ->
-      let objdump = first_success [
-          find_objdump;
-          which "gobjdump";
-          find_in_cellar "gobjdump"; ] in
-      let cxxfilt = first_success [
-          find_cxxfilt;
-          which "c++filt";
-          find_in_cellar "c++filt"; ] in
-      let pathes = match cellar () with
-        | None -> all_pathes ()
-        | Some cellar -> cellar :: all_pathes () in
-      let t = collect
-          {objdump; cxxfilt; objdumps=[]; cxxfilts=[]}
-          pathes in
-      write t
-    | s ->
-      eprintf "unsupported OS %s\n" s;
-      exit 1
+    let pathes = match "%{os}%" with
+      | "linux" -> all_pathes ()
+      | "macos" ->
+        let pathes = match cmd "brew --cellar" with
+          | None -> all_pathes ()
+          | Some cellar ->
+            collect_leaf_folders cellar @ all_pathes () in
+        pathes
+      | s ->
+        eprintf "unsupported OS %s\n" s;
+        exit 1 in
+    write @@ collect t pathes
   with e ->
     eprintf "build failed: %s\n" (Printexc.to_string e);
     exit 1

--- a/packages/conf-binutils/conf-binutils.0.2/files/find-binutils.ml.in
+++ b/packages/conf-binutils/conf-binutils.0.2/files/find-binutils.ml.in
@@ -1,6 +1,14 @@
-#load "unix.cma"
-
 open Printf
+
+
+type t = {
+  objdump  : string option;
+  cxxfilt  : string option;
+  objdumps : string list;
+  cxxfilts : string list;
+}
+
+let (/) = Filename.concat
 
 let read_all ch =
   let buf = Buffer.create 16 in
@@ -21,8 +29,8 @@ let split_on_char sep s =
   done;
   String.sub s 0 !j :: !r
 
-let split str =
-  List.map String.trim (split_on_char '\n' str) |>
+let split ~on str =
+  List.map String.trim (split_on_char on str) |>
   List.filter (fun s -> s <> "")
 
 exception Command_failed of Unix.process_status
@@ -55,12 +63,12 @@ let split_results fmt =
   let run c =
     match cmd "%s" c with
     | None -> []
-    | Some s -> split s in
+    | Some s -> split ~on:'\n' s in
   ksprintf run fmt
 
-let string_of_targets targets =
+let string_of_list xs =
   List.fold_left (fun acc x ->
-      sprintf "%s\"%s\"; " acc x) "[" targets ^ "]"
+      sprintf "%s\"%s\"; " acc x) "[" xs ^ "]"
 
 let is_none = function
   | None -> true
@@ -70,9 +78,9 @@ let failed_to_find cmd =
   eprintf "%s not found\n" cmd;
   exit 1
 
-let write objdump cxxfilt targets =
+let write {objdump; objdumps; cxxfilt; cxxfilts;} =
   if is_none objdump then failed_to_find "objdump";
-  if is_none cxxfilt then failed_to_find "cxxfilt";
+  if is_none cxxfilt then failed_to_find "c++filt";
   let digest path = Digest.to_hex (Digest.file path) in
   let depends = function
     | None -> ""
@@ -85,40 +93,20 @@ let write objdump cxxfilt targets =
     let deps = String.concat " " [depends objdump; depends cxxfilt] in
     if deps = "" then ""
     else sprintf "file-depends: [ %s ]" deps in
-  let targets = string_of_targets targets in
   let oc = open_out "%{_:name}%.config" in
-  let cxxfilt = get cxxfilt in
-  let objdump = get objdump in
   fprintf oc {|
 opam-version: "2.0"
 %s
 variables {
   cxxfilt: %S
+  cxxfilts: %S
   objdump: %S
-  targets: %S
+  objdumps: %S
 }
-|} file_depends cxxfilt objdump targets;
+|} file_depends
+    (get cxxfilt) (string_of_list cxxfilts)
+    (get objdump) (string_of_list objdumps);
   close_out oc
-
-let collect_objdumps () =
-  let find where =
-    split_results
-      "find %s -name \"*objdump\" -executable -type f" where in
-  find "/bin" @ find "/usr"
-
-let collect_targets objdumps =
-  let has_prefix str pref =
-    let len = String.length pref in
-    len <= String.length str &&
-    String.(sub str 0 len = pref) in
-  List.fold_left (fun acc obj ->
-      let file = Filename.basename obj in
-      if file = "objdump" || file = "gobjdump" || has_prefix file "llvm"
-      then acc
-      else
-      if Filename.check_suffix file "-objdump" then
-        Filename.chop_suffix file "-objdump" :: acc
-      else acc) [] objdumps
 
 let which name () = cmd "which %s" name
 
@@ -126,13 +114,15 @@ let of_env var () =
   try Some (Sys.getenv var)
   with Not_found -> None
 
+let cellar () = cmd "brew --cellar"
+
 let find_in_cellar name () =
   match cmd "brew --cellar" with
   | None -> None
   | Some cellar ->
     match cmd "find %s/binutils -name %s" cellar name with
     | None -> None
-    | Some s -> match split s with
+    | Some s -> match split ~on:'\n' s with
       | [] -> None
       | x :: _ -> Some x
 
@@ -152,11 +142,58 @@ let find_objdump () =
     of_env "OBJDUMP_PATH";
   ]
 
-let find_cppfilt () =
+let find_cxxfilt () =
   first_success [
     of_opam_config "%{cxxfilt-path}%";
     of_env "CXXFILT_PATH";
   ]
+
+let all_pathes () =
+  match of_env "PATH" () with
+  | None -> []
+  | Some r -> split r ~on:':'
+
+let filter_objdumps objs =
+  let has_prefix str pref =
+    let len = String.length pref in
+    len <= String.length str &&
+    String.(sub str 0 len = pref) in
+  List.fold_left (fun acc obj ->
+      let file = Filename.basename obj in
+      if file = "objdump" || file = "gobjdump" || has_prefix file "llvm"
+      then acc
+      else
+      if Filename.check_suffix file "-objdump" then
+        Filename.chop_suffix file "-objdump" :: acc
+      else acc) [] objs
+
+let has_prefix str pref =
+  let len = String.length pref in
+  len <= String.length str &&
+  String.(sub str 0 len = pref)
+
+let collect t pathes =
+  let is_known fullpath = function
+    | None -> false
+    | Some x -> x = fullpath in
+  let is_objdump path file =
+    Filename.check_suffix file "objdump" &&
+    not (is_known (path/file) t.objdump) &&
+    not (has_prefix file "llvm") in
+  let is_cxxfilt path file =
+    not (is_known (path/file) t.cxxfilt) &&
+    Filename.check_suffix file "c++filt" in
+  let find t path =
+    if Sys.file_exists path && Sys.is_directory path then
+      Sys.readdir path |>
+      Array.fold_left (fun t file ->
+          if is_objdump path file then
+            {t with objdumps = path / file :: t.objdumps}
+          else if is_cxxfilt path file then
+            {t with cxxfilts = path / file :: t.cxxfilts}
+          else t) t
+    else t in
+  List.fold_left find t pathes
 
 let () =
   try
@@ -166,24 +203,28 @@ let () =
           find_objdump;
           which "objdump"] in
       let cxxfilt = first_success [
-          find_cppfilt;
+          find_cxxfilt;
           which "c++filt"] in
-      let objdumps = collect_objdumps () in
-      let targets = collect_targets objdumps in
-      write objdump cxxfilt targets
+      let t = collect
+          {objdump; cxxfilt; objdumps=[]; cxxfilts=[]}
+          (all_pathes ()) in
+      write t
     | "macos" ->
       let objdump = first_success [
           find_objdump;
           which "gobjdump";
           find_in_cellar "gobjdump"; ] in
       let cxxfilt = first_success [
-          find_cppfilt;
+          find_cxxfilt;
           which "c++filt";
-          find_in_cellar "cppfilt"; ] in
-      let objdumps = split_results "mdfind -name objdump" in
-      let objdumps = List.filter (fun x -> not (Sys.is_directory x)) objdumps in
-      let targets = collect_targets objdumps in
-      write objdump cxxfilt targets
+          find_in_cellar "c++filt"; ] in
+      let pathes = match cellar () with
+        | None -> all_pathes ()
+        | Some cellar -> cellar :: all_pathes () in
+      let t = collect
+          {objdump; cxxfilt; objdumps=[]; cxxfilts=[]}
+          pathes in
+      write t
     | s ->
       eprintf "unsupported OS %s\n" s;
       exit 1

--- a/packages/conf-binutils/conf-binutils.0.2/files/find-binutils.ml.in
+++ b/packages/conf-binutils/conf-binutils.0.2/files/find-binutils.ml.in
@@ -140,10 +140,6 @@ let of_opam_config var () = match var with
   | "" -> None
   | x  -> Some x
 
-let is_some = function
-  | Some _ -> true
-  | None -> false
-
 let rec first_success = function
   | [] -> None
   | f :: fs ->  match f () with
@@ -151,13 +147,16 @@ let rec first_success = function
     | r -> r
 
 let find_objdump () =
-  first_success
-    [of_opam_config "%{objdump-path}%";
-     of_env "OBJDUMP_PATH";]
+  first_success [
+    of_opam_config "%{objdump-path}%";
+    of_env "OBJDUMP_PATH";
+  ]
 
 let find_cppfilt () =
-  first_success [of_opam_config "%{cxxfilt-path}%";
-                 of_env "CXXFILT_PATH";]
+  first_success [
+    of_opam_config "%{cxxfilt-path}%";
+    of_env "CXXFILT_PATH";
+  ]
 
 let () =
   try

--- a/packages/conf-binutils/conf-binutils.0.2/files/find-binutils.ml.in
+++ b/packages/conf-binutils/conf-binutils.0.2/files/find-binutils.ml.in
@@ -47,9 +47,7 @@ let cmd fmt =
       | Unix.WEXITED 0 -> Some res
       | s -> raise (Command_failed s)
     with e ->
-      printf "got an exception!\n";
       eprintf "command %s failed: %s\n" c (exn_to_string e);
-      printf "none will be returned\n";
       None in
   ksprintf run fmt
 

--- a/packages/conf-binutils/conf-binutils.0.3/files/find-binutils.ml.in
+++ b/packages/conf-binutils/conf-binutils.0.3/files/find-binutils.ml.in
@@ -1,0 +1,221 @@
+open Printf
+open StdLabels
+
+type file = {
+  path : string;
+  dgst : string;
+}
+
+type tool = {
+  test  : string -> bool;
+  main  : file option;
+  files : file list;
+}
+
+module Digests = Set.Make(String)
+module Names = Map.Make(String)
+
+type t = tool Names.t
+
+let (/) = Filename.concat
+
+let digest path = Digest.to_hex (Digest.file path)
+
+let input_all ch =
+  let buf = Buffer.create 4096 in
+  let rec read () = Buffer.add_channel buf ch 4096; read () in
+  try read ()
+  with End_of_file -> String.trim @@ Buffer.contents buf
+
+let split_on_char sep s =
+  let r = ref [] in
+  let j = ref (String.length s) in
+  for i = String.length s - 1 downto 0 do
+    if s.[i] = sep then begin
+      r := String.sub s (i + 1) (!j - i - 1) :: !r;
+      j := i
+    end
+  done;
+  String.sub s 0 !j :: !r
+
+let split ~on str =
+  List.map String.trim (split_on_char on str) |>
+  List.filter ~f:(fun s -> s <> "")
+
+exception Command_failed of Unix.process_status
+
+let process_status_to_string s =
+  let open Unix in
+  match s with
+  | WEXITED i -> sprintf "exit status %d" 1
+  | WSTOPPED i -> sprintf "proccess was stopped by signal %d" i
+  | WSIGNALED i -> sprintf "proccess was killed by signal %d" i
+
+let exn_to_string = function
+  | Command_failed s -> sprintf "%s" (process_status_to_string s)
+  | e -> Printexc.to_string e
+
+let cmd fmt =
+  let run c =
+    try
+      let inp = Unix.open_process_in c in
+      let res = input_all inp in
+      match Unix.close_process_in inp with
+      | Unix.WEXITED 0 -> Some res
+      | s -> raise (Command_failed s)
+    with e ->
+      eprintf "command %s failed: %s\n" c (exn_to_string e);
+      None in
+  ksprintf run fmt
+
+let string_of_files xs =
+  List.fold_left xs ~f:(fun s {path} ->
+      sprintf "%s\"%s\"; " s path) ~init:"[" ^ "]"
+
+let is_none = function
+  | None -> true
+  | _ -> false
+
+let failed_to_find cmd =
+  eprintf "%s not found\n" cmd;
+  exit 1
+
+let dedup main files =
+  fst @@
+  List.fold_left files
+    ~init:([], Digests.add main.dgst Digests.empty)
+    ~f:(fun ((files, digests) as acc) ({dgst} as file) ->
+        if Digests.mem dgst digests
+        then acc
+        else file :: files, Digests.add dgst digests)
+
+let dependencies ~init files =
+  List.fold_left files ~init ~f:(fun depends {path; dgst} ->
+      sprintf " [ %S %S ] " path dgst :: depends)
+
+let write t =
+  let deps, vars =
+    Names.fold (fun name {main; files} (deps, vars) ->
+        let main, files = match main, files with
+          | None, [] -> failed_to_find name
+          | None, main :: files -> main, files
+          | Some main, files -> main, files in
+        let files = dedup main files in
+        let files = main :: files in
+        let deps = dependencies ~init:deps files in
+        let files = sprintf "%s: %S" name (string_of_files files) in
+        deps, files :: vars) t ([], [])  in
+  let oc = open_out "%{_:name}%.config" in
+  let deps = String.concat "\n" deps in
+  let vars = String.concat "\n" vars in
+  fprintf oc {|
+opam-version: "2.0"
+file-depends: [ %s ]
+variables {
+%s
+}
+|} deps vars;
+  close_out oc
+
+let of_env var () =
+  try Some (Sys.getenv var)
+  with Not_found -> None
+
+let of_opam_config var () = match var with
+  | "" -> None
+  | x  -> Some x
+
+let match_files path files test =
+  Array.fold_left files ~init:[] ~f:(fun acc file ->
+      if test file then
+        let path = path / file in
+        {path; dgst = digest path} :: acc
+      else acc)
+
+let update t path  =
+  if Sys.is_directory path then
+    let files = Sys.readdir path in
+    Names.fold (fun name tool t ->
+        let files = match_files path files tool.test in
+        Names.add name {tool with files = tool.files @ files} t) t t
+  else t
+
+let collect t paths = List.fold_left paths ~f:update ~init:t
+
+let search t path =
+  let rec loop t path =
+    if Sys.is_directory path
+    then
+      Sys.readdir path |>
+      Array.fold_left ~init:t ~f:(fun t file -> loop t @@ path / file)
+    else
+      Names.fold (fun name tool t ->
+          if tool.test (Filename.basename path)
+          then
+            let file = {path; dgst = digest path} in
+            Names.add name {tool with files = tool.files @ [file]} t
+          else t) t t in
+  loop t path
+
+let rec first_success = function
+  | [] -> None
+  | f :: fs -> match f () with
+    | None -> first_success fs
+    | r -> r
+
+let is_dir p = Sys.file_exists p && Sys.is_directory p
+
+let all_paths () =
+  match of_env "PATH" () with
+  | None -> []
+  | Some r -> List.filter ~f:is_dir (split r ~on:':')
+
+let has_prefix str pref =
+  let len = String.length pref in
+  len <= String.length str &&
+  String.sub str 0 len = pref
+
+let is_llvm_tool file = has_prefix file "llvm"
+
+let check ~suffix file =
+  Filename.check_suffix file suffix &&
+  not (is_llvm_tool file)
+
+let add_var name ?(opam="") ?(env="") ~suffix t =
+  let main =
+    match first_success [of_opam_config opam; of_env env] with
+    | None -> None
+    | Some path -> Some {path; dgst = digest path } in
+  Names.add name {test = check ~suffix; main; files = []} t
+
+let t =
+  add_var "objdumps"
+    ~opam:"%{objdump-path}%"
+    ~env:"OBJDUMP_PATH"
+    ~suffix:"objdump"
+    Names.empty |>
+  add_var "cxxfilts"
+    ~opam:"%{cxxfilt-path}%"
+    ~env:"CXXFILT_PATH"
+    ~suffix:"c++filt" |>
+  add_var "readelfs"
+    ~opam:"%{readelf-path}%"
+    ~env:"READELF_PATH"
+    ~suffix:"readelf"
+
+
+let () =
+  try
+    match "%{os}%" with
+    | "linux" -> write @@ collect t @@ all_paths ()
+    | "macos" ->
+      let t = match cmd "brew --cellar" with
+        | None -> t
+        | Some cellar -> search t cellar in
+      write @@ collect t @@ all_paths ()
+    | s ->
+      eprintf "unsupported OS %s\n" s;
+      exit 1
+  with e ->
+    eprintf "build failed: %s\n" (Printexc.to_string e);
+    exit 1

--- a/packages/conf-binutils/conf-binutils.0.3/opam
+++ b/packages/conf-binutils/conf-binutils.0.3/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+name: "conf-binutils"
+version: "0.3"
+maintainer: "Ivan Gotovchits <ivg@ieee.org>"
+authors: "BAP Team"
+homepage: "https://github.com/BinaryAnalysisPlatform/bap/"
+bug-reports: "https://github.com/BinaryAnalysisPlatform/bap/issues"
+dev-repo: "git://github.com/BinaryAnalysisPlatform/bap/"
+license: "MIT"
+build: [
+  ["ocaml" "unix.cma" "find-binutils.ml"]
+]
+
+depexts: [
+  ["binutils-multiarch"] {os-family = "debian"}
+  ["binutils"] {os = "macos" & os-distribution = "homebrew"}
+  [
+    "arm-aout-binutils"
+    "arm-elf-binutils"
+    "arm-none-eabi-binutils"
+    "i386-elf-binutils"
+    "i386-mingw32-binutils"
+    "x86_64-elf-binutils"
+  ] {os = "macos" & os-distribution = "macports"}
+]
+synopsis: "Checks that binutils are installed"
+
+depends: [
+  "ocaml"
+  "base-unix"
+]
+
+substs: [ "find-binutils.ml" ]
+flags: [ conf ]

--- a/packages/conf-libclang/conf-libclang.10/files/configure.sh
+++ b/packages/conf-libclang/conf-libclang.10/files/configure.sh
@@ -10,7 +10,8 @@ find_llvm_config () {
         fi
         for llvm_config in \
             llvm-config-${version} llvm-config-${version}.0 \
-            llvm-config${version}0 llvm-config-mp-$version \
+            llvm-config${version}0 llvm-config${version} \
+            llvm-config-mp-$version \
             llvm-config-mp-${version}.0 $brew_llvm_config \
             /usr/lib64/llvm/${version}/bin/llvm-config \
             /usr/lib/llvm/${version}/bin/llvm-config \

--- a/packages/conf-libclang/conf-libclang.10/opam
+++ b/packages/conf-libclang/conf-libclang.10/opam
@@ -17,11 +17,11 @@ depexts: [
   ["clang-devel" "llvm-devel" "zlib-devel" "redhat-rpm-config"]
     {os-distribution = "fedora"}
   ["llvm-clang-devel"] {os-family = "suse"}
-#  ["devel/clang" "devel/llvm"] {os = "freebsd"}
+  ["devel/llvm10"] {os = "freebsd"}
   ["sys-devel/clang"] {os-distribution = "gentoo"}
 ]
 extra-files: [[
-  "configure.sh" "sha512=3cb05a41bed0441d44c6e73561741e85e2ddd23d8df1c645d45048a911d62bf3d82d726e9fc8a279ee28f9a0cc73612558dec5f223291646be73c391f21823d4"
+  "configure.sh" "sha512=8c95b2f06ce5bc161fd68ff8f8ddc0b9b7ea1a318732b79e4131d0adf9222662dd95a60becf28ef5db83fecf1081266a6ccf128864c019571948a232ba18fe82"
 ]]
 synopsis: "Virtual package relying on the installation of llvm and clang libraries (any version)"
 flags: conf

--- a/packages/refl/refl.0.2.1/opam
+++ b/packages/refl/refl.0.2.1/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "PPX deriver for reflection"
+description: """
+PPX deriver for reflection
+"""
+maintainer: ["Thierry Martinez <thierry.martinez@inria.fr>"]
+authors: ["Thierry Martinez <thierry.martinez@inria.fr>"]
+license: "BSD-2-Clause"
+homepage: "https://github.com/thierry-martinez/refl"
+doc: "https://github.com/thierry-martinez/refl"
+bug-reports: "https://github.com/thierry-martinez/refl"
+depends: [
+  "ocaml" {>= "4.03.0" & < "4.12.0"}
+  "dune" {>= "1.11.0"}
+  "stdcompat" {>= "14"}
+  "fix" {>= "20200131"}
+  "metapp" {>= "0.2.0"}
+  "metaquot" {>= "0.2.0"}
+  "traverse" {>= "0.2.0"}
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/thierry-martinez/refl"
+url {
+  src: "https://github.com/thierry-martinez/refl/archive/v0.2.1.tar.gz"
+  checksum: "sha512=e7eeb7e3a2831db4fccc9e133b63bfac950f231350ff5f726d800bc0a7a2eb1313d38ffff0e1a0b399ca431cd8b9c792b5a2846f537775df8f338b1e1670e5d9"
+}


### PR DESCRIPTION
the modern brew binutils formula doesn't appear in the user path, and `brew link` refuses to link it even with
`--force` option applied. That's why we need to improve the search and look for `gobjdump` and `c++filt`  utils right in the brew's
cellar folder.